### PR TITLE
Updated FinalDraft and Release manifests for partial-set

### DIFF
--- a/input/resources/library/Manifest-Partial-Set-FinalDraft-2025.json
+++ b/input/resources/library/Manifest-Partial-Set-FinalDraft-2025.json
@@ -13,51 +13,51 @@
             "parameter": [
                 {
                     "name": "system-version",
-                    "valueUri": "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901"
+                    "valueCanonical": "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://loinc.org|2.76"
+                    "valueCanonical": "http://loinc.org|2.76"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
+                    "valueCanonical": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0"
+                    "valueCanonical": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "urn:oid:2.16.840.1.113883.6.238|1.2"
+                    "valueCanonical": "urn:oid:2.16.840.1.113883.6.238|1.2"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.ama-assn.org/go/cpt|2024"
+                    "valueCanonical": "http://www.ama-assn.org/go/cpt|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://hl7.org/fhir/sid/cvx|20231102"
+                    "valueCanonical": "http://hl7.org/fhir/sid/cvx|20231102"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|2024"
+                    "valueCanonical": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://hl7.org/fhir/sid/icd-10-cm|2024"
+                    "valueCanonical": "http://hl7.org/fhir/sid/icd-10-cm|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.cms.gov/Medicare/Coding/ICD10|2024"
+                    "valueCanonical": "http://www.cms.gov/Medicare/Coding/ICD10|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.nlm.nih.gov/research/umls/rxnorm|01022024"
+                    "valueCanonical": "http://www.nlm.nih.gov/research/umls/rxnorm|01022024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "https://nahdo.org/sopt|9.2"
+                    "valueCanonical": "https://nahdo.org/sopt|9.2"
                 }
             ]
         },

--- a/input/resources/library/Manifest-Partial-Set-Release-2025.json
+++ b/input/resources/library/Manifest-Partial-Set-Release-2025.json
@@ -1,9 +1,9 @@
 {
     "resourceType": "Library",
-    "id": "Manifest-Partial-Set-FinalDraft-2025",
+    "id": "Manifest-Partial-Set-Release-2025",
     "meta": {
-        "versionId": "4",
-        "lastUpdated": "2025-07-24T15:54:30.473-06:00",
+        "versionId": "2",
+        "lastUpdated": "2025-07-30T12:47:14.305-06:00",
         "profile": [
             "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-manifestlibrary"
         ]
@@ -15,3511 +15,3511 @@
             "parameter": [
                 {
                     "name": "system-version",
-                    "valueUri": "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901"
+                    "valueCanonical": "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://loinc.org|2.76"
+                    "valueCanonical": "http://loinc.org|2.76"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
+                    "valueCanonical": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0"
+                    "valueCanonical": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "urn:oid:2.16.840.1.113883.6.238|1.2"
+                    "valueCanonical": "urn:oid:2.16.840.1.113883.6.238|1.2"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.ama-assn.org/go/cpt|2024"
+                    "valueCanonical": "http://www.ama-assn.org/go/cpt|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://hl7.org/fhir/sid/cvx|20231102"
+                    "valueCanonical": "http://hl7.org/fhir/sid/cvx|20231102"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|2024"
+                    "valueCanonical": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://hl7.org/fhir/sid/icd-10-cm|2024"
+                    "valueCanonical": "http://hl7.org/fhir/sid/icd-10-cm|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.cms.gov/Medicare/Coding/ICD10|2024"
+                    "valueCanonical": "http://www.cms.gov/Medicare/Coding/ICD10|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.nlm.nih.gov/research/umls/rxnorm|01022024"
+                    "valueCanonical": "http://www.nlm.nih.gov/research/umls/rxnorm|01022024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "https://nahdo.org/sopt|9.2"
+                    "valueCanonical": "https://nahdo.org/sopt|9.2"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS22FHIRPCSBPScreeningFollowUp|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS22FHIRPCSBPScreeningFollowUp|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263|20240206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263|20240206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.259|20250201"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.259|20250201"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.261|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.261|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1512|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1512|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1511|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1511|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.274|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.274|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1918|20240206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1918|20240206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1497|20240206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1497|20240206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1125|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1125|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.192|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.192|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1115|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1115|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2466|20220217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2466|20220217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514|20190313"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514|20190313"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2395|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2395|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.512|20190313"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.512|20190313"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.513|20200307"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.513|20200307"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578|20200307"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578|20200307"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1537|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1537|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.125|20240125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.125|20240125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.124|20240125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.124|20240125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2462|20250201"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.2462|20250201"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581|20200307"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581|20200307"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1508|20250129"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1508|20250129"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.313|20220226"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.313|20220226"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582|20200307"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582|20200307"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.791|20250325"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.791|20250325"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1476|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1476|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518|20190313"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518|20190313"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.810|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.810|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1516|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1516|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583|20200307"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583|20200307"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.823|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.823|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1475|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1475|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1509|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1509|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.805|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.805|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS68FHIRDocumentationofCurrentMedications|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS68FHIRDocumentationofCurrentMedications|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1917|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1917|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1608|20250123"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1608|20250123"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1609|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1609|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.242|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.242|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.243|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.243|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202|20240209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202|20240209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.245|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.245|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.246|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.246|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76|20221115"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76|20221115"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473|20220212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473|20220212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS72FHIRSTKAntithromboticDay2|0.7.002"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS72FHIRSTKAntithromboticDay2|0.7.002"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62|20210409"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62|20210409"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.61|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.61|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.213|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.213|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.21|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.21|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.21|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.21|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.15|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.15|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.16|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.16|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.56|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.56|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.55|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.55|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.51|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.51|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.226|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.226|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS104FHIRSTKDCAntithrombotic|0.9.003"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS104FHIRSTKDCAntithrombotic|0.9.003"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS122FHIRDiabetesAssessGreaterThan9Percent|0.5.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS122FHIRDiabetesAssessGreaterThan9Percent|0.5.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1363|20231221"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1363|20231221"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1772|20240206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1772|20240206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001|20250115"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001|20250115"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1273|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1273|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1272|20250115"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1272|20250115"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1024|20230210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1024|20230210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016|20240110"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016|20240110"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1265|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1265|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1080|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1080|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006|20210819"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006|20210819"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1004|20210924"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1004|20210924"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1005|20210819"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1005|20210819"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.11.1003|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.11.1003|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001|20180310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001|20180310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1005|20231116"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1005|20231116"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1264|20250118"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1264|20250118"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1260|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1260|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1287|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1287|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS124FHIRCervicalCancerScreening|0.4.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS124FHIRCervicalCancerScreening|0.4.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016|20240106"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016|20240106"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.112.11.1025|20210915"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.112.11.1025|20210915"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.112.11.1024|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.112.11.1024|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.11.1135|20241106"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.11.1135|20241106"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1135|20200310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1135|20200310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1027|20241107"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1027|20241107"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1026|20230207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1026|20230207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089|20210224"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089|20210224"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1281|20231116"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1281|20231116"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1282|20231116"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1282|20231116"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1044|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1044|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS125FHIRBreastCancerScreening|0.4.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS125FHIRBreastCancerScreening|0.4.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005|20240105"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005|20240105"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1140|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1140|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1005|20240206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1005|20240206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1084|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1084|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1085|20250109"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1085|20250109"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1018|20210304"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1018|20210304"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047|20241107"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047|20241107"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069|20171216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069|20171216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1086|20180310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1086|20180310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1091|20171216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1091|20171216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070|20171216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070|20171216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1092|20171216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1092|20171216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1087|20180310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1087|20180310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1144|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1144|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1132|20211020"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1132|20211020"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1145|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1145|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1133|20211020"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1133|20211020"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1090|20171216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1090|20171216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1089|20171216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1089|20171216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS130FHIRColorectalCancerScreening|0.4.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS130FHIRColorectalCancerScreening|0.4.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1051|20231116"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1051|20231116"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1053|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1053|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1052|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1052|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.11.1097|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.11.1097|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1020|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1020|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1145|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1145|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1017|20240207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1017|20240207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1015|20230207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1015|20230207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1016|20171219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1016|20171219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1001|20241106"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1001|20241106"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1003|20230211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1003|20230211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1143|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1143|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1036|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1036|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1035|20240207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1035|20240207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS133FHIRCataracts2040BCVAwithin90Days|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS133FHIRCataracts2040BCVAwithin90Days|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1509|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1509|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1344|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1344|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1626|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1626|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1628|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1628|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1781|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1781|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1523|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1523|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1521|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1521|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1530|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1530|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1529|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1529|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1534|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1534|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1532|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1532|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1537|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1537|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1535|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1535|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1524|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1524|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1526|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1526|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1527|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1527|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1528|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1528|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1578|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1578|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1577|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1577|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1538|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1538|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1540|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1540|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1632|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1632|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1634|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1634|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1637|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1637|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1635|20241228"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1635|20241228"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1640|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1640|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1638|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1638|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1542|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1542|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1543|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1543|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1546|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1546|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1544|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1544|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1549|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1549|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1548|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1548|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1643|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1643|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1641|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1641|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1646|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1646|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1644|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1644|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1649|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1649|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1647|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1647|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.76|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.76|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.80|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.80|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1552|20210210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1552|20210210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1550|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1550|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1653|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1653|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1655|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1655|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1656|20210406"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1656|20210406"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1658|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1658|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1661|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1661|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1659|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1659|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1662|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1662|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1664|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1664|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1562|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1562|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1561|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1561|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1665|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1665|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1667|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1667|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1670|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1670|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1668|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1668|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1564|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1564|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1566|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1566|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1671|20240209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1671|20240209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1673|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1673|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1572|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1572|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1571|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1571|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1574|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1574|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1575|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1575|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1770|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1770|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1769|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1769|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1767|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1767|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1766|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1766|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465|20210308"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465|20210308"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1679|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1679|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1677|20210308"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1677|20210308"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430|20210406"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430|20210406"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1582|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1582|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1583|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1583|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1680|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1680|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1682|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1682|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1683|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1683|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1685|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1685|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1686|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1686|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1688|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1688|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1689|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1689|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1691|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1691|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1695|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1695|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1697|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1697|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1703|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1703|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1701|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1701|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1722|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1722|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1724|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1724|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1587|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1587|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1588|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1588|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433|20210314"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433|20210314"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1590|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1590|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1591|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1591|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1707|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1707|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1709|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1709|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1713|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1713|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1715|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1715|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1716|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1716|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1718|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1718|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1719|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1719|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1721|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1721|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1601|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1601|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1603|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1603|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1|20210308"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1|20210308"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.2|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.2|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.3|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.3|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1730|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1730|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1728|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1728|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1613|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1613|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1612|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1612|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1617|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1617|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1615|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1615|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1620|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1620|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1618|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1618|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1731|20210214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1731|20210214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1623|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1623|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1621|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1621|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS135FHIRHFACEIorARBorARNIforLVSD|0.4.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS135FHIRHFACEIorARBorARNIforLVSD|0.4.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1489|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1489|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1926|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1926|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1139|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1139|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.39|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.39|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1211|20170908"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1211|20170908"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1256|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1256|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1212|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1212|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1257|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1257|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.311|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.311|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1140|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1140|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.305|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.305|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.532|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.532|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.242|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.242|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.861|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.861|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014|20240203"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014|20240203"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1262|20180310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1262|20180310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1377|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1377|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1381|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1381|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1364|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1364|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012|20240110"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012|20240110"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1261|20180310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1261|20180310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1060|20240203"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1060|20240203"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.111|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.111|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1771|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1771|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008|20240110"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008|20240110"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1266|20200310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1266|20200310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1040|20240203"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1040|20240203"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391|20130614"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391|20130614"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS143FHIRPOAGOpticNerveEvaluation|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS143FHIRPOAGOpticNerveEvaluation|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1402|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1402|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1216|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1216|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1403|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1403|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.74|20250125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.74|20250125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.73|20210209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.73|20210209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS144FHIRHFBetaBlockerTherapyforLVSD|1.5.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS144FHIRHFBetaBlockerTherapyforLVSD|1.5.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1333|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1333|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.186|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.186|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.181|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.181|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.60|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.60|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.61|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.61|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.187|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.187|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.264|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.264|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1342|20220216"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1342|20220216"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1921|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1921|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.411|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.411|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.408|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.408|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.52|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.52|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.65|20221105"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.65|20221105"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.183|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.183|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1924|20230210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1924|20230210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.180|20230316"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.180|20230316"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.185|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.185|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1334|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1334|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD|0.4.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD|0.4.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1174|20210303"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1174|20210303"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.133|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.133|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.371|20210218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.371|20210218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.168|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.168|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.169|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.169|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.369|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.369|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.120|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.120|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.57|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.57|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1238|20250128"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1238|20250128"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.860|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.860|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403|20240125"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403|20240125"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.58|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.58|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.119|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.119|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1049|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1049|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1009|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1009|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.310|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.310|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS149FHIRDementiaCognitiveAssessment|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS149FHIRDementiaCognitiveAssessment|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1064|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1064|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1775|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1775|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1401|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1401|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1068|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1068|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1067|20240202"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1067|20240202"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1063|20170823"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1063|20170823"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1774|20210909"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1774|20210909"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1923|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1923|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1776|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1776|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1927|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1927|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1777|20190315"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1777|20190315"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1069|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1069|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS159FHIRDepressionRemissionatTwelveMonths|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS159FHIRDepressionRemissionatTwelveMonths|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128|20240214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128|20240214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.45|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.45|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.44|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.44|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1080.5|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1080.5|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1080.6|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1080.6|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1080.7|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1080.7|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.254|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.254|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.257|20230318"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.257|20230318"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.256|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.256|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307|20200307"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307|20200307"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584|20210825"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584|20210825"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15|20240207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15|20240207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1008|20210821"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1008|20210821"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1007|20210824"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1007|20210824"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165|20220818"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165|20220818"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1166|20220817"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1166|20220817"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003|20210820"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003|20210820"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1002|20230208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1002|20230208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1001|20210820"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1001|20210820"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.113883.3.67.1.101.3.2444|20210219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.113883.3.67.1.101.3.2444|20210219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1060|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1060|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1017|20230124"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1017|20230124"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1019|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1019|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1062|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1062|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167|20220820"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167|20220820"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1168|20220819"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1168|20220819"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1169|20220820"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1169|20220820"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090|20210224"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090|20210224"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1285|20250110"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1285|20250110"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1286|20240207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1286|20240207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135|20210224"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135|20210224"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1148|20230118"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1148|20230118"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579|20210224"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579|20210224"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1578|20210222"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1578|20210222"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.246|20240214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.246|20240214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.249|20230318"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.249|20230318"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.248|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.248|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1152|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1152|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1178|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1178|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1180|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1180|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.263|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.263|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1104|20240214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1104|20240214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1162|20220219"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1162|20220219"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1163|20250208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.11.1163|20250208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS190VTEProphylaxisICUFHIR|0.3.001"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS190VTEProphylaxisICUFHIR|0.3.001"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS0334FHIRPCCesareanBirth|0.6.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS0334FHIRPCCesareanBirth|0.6.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.103|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.103|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.171|20240209"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.171|20240209"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.367|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.367|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.369|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.369|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.173|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.173|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.98|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.98|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.58|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.58|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.401|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.401|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049|20180310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049|20180310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.11.1124|20240323"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.11.1124|20240323"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.11.1123|20240323"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.11.1123|20240323"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.36|20240208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.36|20240208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.77|20240208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.77|20240208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.72|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.72|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.73|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.73|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS506FHIRSafeUseofOpioids|0.3.007"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS506FHIRSafeUseofOpioids|0.3.007"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.180|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.180|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.178|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.178|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.179|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.179|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365|20250515"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365|20250515"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.269|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.269|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.177|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.177|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.225|20240221"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.225|20240221"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.171|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.171|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.242|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.242|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.243|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.243|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.241|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.241|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.70|20240221"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.70|20240221"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.15|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.15|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.72|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.72|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.14|20200310"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.14|20200310"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.13|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.13|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.16|20240221"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.16|20240221"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.74|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.74|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.12|20220305"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.12|20220305"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.71|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.71|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.11|20230301"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.11|20230301"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.12|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.12|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.76|20240221"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.76|20240221"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.77|20240221"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.77|20240221"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.17|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.17|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.75|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.75|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.73|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1002.73|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.18|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.1004.18|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.146|20220308"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.146|20220308"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.169|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.169|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.167|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.167|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.168|20210223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.168|20210223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.175|20240215"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.175|20240215"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.173|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.173|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.174|20240217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.174|20240217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationTherapy|1.5.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationTherapy|1.5.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.352|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.352|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.359|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.359|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319|20200306"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319|20200306"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.92|20250325"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.92|20250325"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.91|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.91|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCancer|1.5.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCancer|1.5.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.353|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.353|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.354|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.354|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.355|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.355|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.358|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.358|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.357|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.357|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.356|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.356|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003|20240106"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003|20240106"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1007|20241106"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1007|20241106"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1008|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1008|20230214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1010|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1010|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1005|20240207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.11.1005|20240207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.363|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.363|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.362|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.362|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.361|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.361|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.364|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.364|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.365|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.365|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.351|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.351|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.350|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.350|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.349|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.349|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.369|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.369|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplasia|1.5.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplasia|1.5.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.360|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.360|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.368|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.368|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.366|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.366|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.367|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.367|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.372|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.372|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.370|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.370|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.371|20250312"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.371|20250312"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS816FHIRHHHypo|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS816FHIRHHHypo|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34|20230203"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34|20230203"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS819FHIRHHORAE|0.4.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS819FHIRHHORAE|0.4.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141|20220512"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141|20220512"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226|20240124"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226|20240124"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187|20230204"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187|20230204"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS826FHIRHHPI|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS826FHIRHHPI|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198|20220415"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198|20220415"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197|20220415"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197|20220415"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194|20220415"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194|20220415"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113|20220415"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113|20220415"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.109|20230205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.109|20230205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.110|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.110|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196|20220416"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196|20220416"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS832HHAKIFHIR|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS832HHAKIFHIR|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS871HHHyperFHIR|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS871HHHyperFHIR|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS986FHIRMalnutritionScore|0.3.003"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS986FHIRMalnutritionScore|0.3.003"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.101|20241004"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.101|20241004"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91|20241211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91|20241211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55|20180616"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55|20180616"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.53|20241211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.53|20241211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.54|20250204"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.54|20250204"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.89|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.89|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.94|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.94|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38|20250122"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38|20250122"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.47|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.47|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.98|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.98|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.96|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.96|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.95|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.95|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.43|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.43|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.97|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.97|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42|20241211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42|20241211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93|20240117"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93|20240117"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1017FHIRHHFI|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1017FHIRHHFI|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1258.2|20241012"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1258.2|20241012"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.22|20220608"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.22|20220608"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.131|20240123"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.131|20240123"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.130|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.130|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.163|20240119"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.163|20240119"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.164|20240120"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.164|20240120"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.134|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.134|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.23|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.23|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.168|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.168|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.165|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.165|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.166|20240124"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.166|20240124"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.167|20240208"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.167|20240208"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.169|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.169|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.170|20240118"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.170|20240118"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.171|20250205"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.171|20250205"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.171|20210605"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.171|20210605"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.122|20210605"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.122|20210605"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.119|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.119|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.136|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.136|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.137|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.137|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.120|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.120|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.24|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.24|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1272.1|20241012"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1272.1|20241012"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.205|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.205|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.174|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.174|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.172|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.172|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.173|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.173|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.162|20250211"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.162|20250211"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.120|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.120|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1200.147|20201204"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1200.147|20201204"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.175|20221006"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.175|20221006"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.176|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.176|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.130|20230425"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.130|20230425"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1028FHIRPCSevereOBComps|0.3.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1028FHIRPCSevereOBComps|0.3.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.70|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.70|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.71|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.71|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.233|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.233|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.623|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.623|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.270|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.270|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.53|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.53|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.214|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.214|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.243|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.243|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.217|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.217|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.321|20230218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.321|20230218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.219|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.219|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.309|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.309|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.315|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.315|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.286|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.286|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.246|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.246|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.245|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.245|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.221|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.221|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.339|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.339|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.357|20210121"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.357|20210121"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.247|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.247|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.248|20210121"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.248|20210121"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.223|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.223|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.225|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.225|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.291|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.291|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.368|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.368|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837|20121025"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837|20121025"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.336|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.336|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.267|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.267|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.227|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.227|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.271|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.271|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.330|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.330|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.358|20210121"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.358|20210121"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.249|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.249|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.250|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.250|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.364|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.364|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.312|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.312|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.326|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.326|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.289|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.289|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.282|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.282|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.306|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.306|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1|20150331"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1|20150331"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591|20250419"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591|20250419"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.300|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.300|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.388|20240223"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.388|20240223"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.387|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.387|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.78|20231111"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.78|20231111"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35|20210611"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35|20210611"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.303|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.303|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.274|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.274|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.297|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.297|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278|20220316"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278|20220316"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.277|20230217"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.277|20230217"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.229|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.229|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.231|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.231|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.279|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.279|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836|20121025"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836|20121025"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.333|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.333|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.237|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.237|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.235|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.235|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.241|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.241|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.239|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.239|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256|20230218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256|20230218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.253|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.253|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.251|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.251|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.254|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.254|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.252|20210121"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.252|20210121"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.324|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.324|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.318|20240210"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.318|20240210"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.295|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.295|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.359|20210121"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.359|20210121"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.361|20220127"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.361|20220127"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.360|20210121"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.360|20210121"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129|20230214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1074FHIRCTIQR|0.9.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1074FHIRCTIQR|0.9.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1206FHIRCTOQR|0.8.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1206FHIRCTOQR|0.8.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1218FHIRHHRF|0.2.000"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1218FHIRHHRF|0.2.000"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.88|20230426"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.88|20230426"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.221|20230520"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.221|20230520"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.255|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.255|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.206|20230429"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.206|20230429"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.207|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.207|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.252|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.252|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.253|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.253|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.96|20240109"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.96|20240109"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.217|20230512"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.217|20230512"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.224|20230520"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.224|20230520"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139|20230214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.223|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.223|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.218|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.218|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.95|20240109"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.95|20240109"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.241|20230923"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.241|20230923"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.92|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.92|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.240|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.240|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.85|20230518"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.85|20230518"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.208|20230429"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.208|20230429"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.183|20220720"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.183|20220720"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.93|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.93|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.182|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.182|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.251|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.251|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.250|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.250|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.249|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.249|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.248|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.248|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.247|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.247|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.246|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.246|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.245|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.245|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.243|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.243|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.242|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.242|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.219|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.219|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.179|20220719"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.179|20220719"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.86|20220719"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.86|20220719"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.178|20230519"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.178|20230519"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.222|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.222|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.107|20220507"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.107|20220507"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.105|20220507"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.105|20220507"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.106|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.106|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.239|20230923"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.239|20230923"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.91|20240124"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.91|20240124"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.238|20230923"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.238|20230923"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.213|20230512"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.213|20230512"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.211|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.211|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.210|20230503"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.210|20230503"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.214|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.214|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.209|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.209|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.337|20250206"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.337|20250206"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.335|20240203"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.335|20240203"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.94|20240109"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.94|20240109"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127|20230214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.216|20230512"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.216|20230512"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.220|20240112"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.220|20240112"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119|20220218"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119|20220218"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.89|20220719"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.89|20220719"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.181|20220719"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.181|20220719"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.90|20230429"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.90|20230429"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.180|20240109"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.180|20240109"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1244FHIRECATHOQR|0.4.001"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1244FHIRECATHOQR|0.4.001"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.164|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.164|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.285|20240418"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.285|20240418"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.28|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.28|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.27|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.27|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.294|20210220"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.294|20210220"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.163|20200305"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.163|20200305"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010|20210928"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010|20210928"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1050|20170504"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1050|20170504"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.284|20240418"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.284|20240418"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.277|20240418"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.277|20240418"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.283|20240418"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.283|20240418"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.278|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.278|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.279|20250212"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.279|20250212"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMS1264FHIRECATREHQR|0.5.001"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMS1264FHIRECATREHQR|0.5.001"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.286|20240726"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.286|20240726"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Measure/CMSFHIR844HybridHospitalWideMortality|Draft based on 0.5.001"
+                    "valueCanonical": "https://madie.cms.gov/Measure/CMSFHIR844HybridHospitalWideMortality|Draft based on 0.5.001"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "https://madie.cms.gov/Library/CMSFHIR844HybridHospitalWideMortality|0.5.001"
+                    "valueCanonical": "https://madie.cms.gov/Library/CMSFHIR844HybridHospitalWideMortality|0.5.001"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12|20230214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10|20230214"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.57|20250207"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.57|20250207"
                 },
                 {
                     "name": "canonical-version",
-                    "valueUri": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151|20230214"
+                    "valueCanonical": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151|20230214"
                 }
             ]
         },
@@ -3587,51 +3587,51 @@
             "parameter": [
                 {
                     "name": "system-version",
-                    "valueUri": "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901"
+                    "valueCanonical": "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20230901"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://loinc.org|2.76"
+                    "valueCanonical": "http://loinc.org|2.76"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
+                    "valueCanonical": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0"
+                    "valueCanonical": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender|3.0.0"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "urn:oid:2.16.840.1.113883.6.238|1.2"
+                    "valueCanonical": "urn:oid:2.16.840.1.113883.6.238|1.2"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.ama-assn.org/go/cpt|2024"
+                    "valueCanonical": "http://www.ama-assn.org/go/cpt|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://hl7.org/fhir/sid/cvx|20231102"
+                    "valueCanonical": "http://hl7.org/fhir/sid/cvx|20231102"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|2024"
+                    "valueCanonical": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://hl7.org/fhir/sid/icd-10-cm|2024"
+                    "valueCanonical": "http://hl7.org/fhir/sid/icd-10-cm|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.cms.gov/Medicare/Coding/ICD10|2024"
+                    "valueCanonical": "http://www.cms.gov/Medicare/Coding/ICD10|2024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "http://www.nlm.nih.gov/research/umls/rxnorm|01022024"
+                    "valueCanonical": "http://www.nlm.nih.gov/research/umls/rxnorm|01022024"
                 },
                 {
                     "name": "system-version",
-                    "valueUri": "https://nahdo.org/sopt|9.2"
+                    "valueCanonical": "https://nahdo.org/sopt|9.2"
                 }
             ]
         }
@@ -4638,7 +4638,7 @@
             }
         ]
     },
-    "date": "2025-07-24T15:42:16-06:00",
+    "date": "2025-07-30T12:34:54-06:00",
     "publisher": "Clinical Quality Information WG",
     "contact": [
         {


### PR DESCRIPTION
The value type for expansion parameters has been updated to canonical.